### PR TITLE
test: use precompiled Ruby binary on Netlify

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+ruby.compile = false


### PR DESCRIPTION
Netlify's mise build step compiles Ruby 3.0.2 from source (~3 min). Setting ruby.compile=false tells mise to use a precompiled binary instead, which should be significantly faster.