### PR TITLE
fix: add missing author field to posts excluded from author page

### DIFF
--- a/content/posts/2020/2020-08-07-otel-part-1-sinatra.md
+++ b/content/posts/2020/2020-08-07-otel-part-1-sinatra.md
@@ -1,4 +1,5 @@
 ---
+author: gene
 title: 'OpenTelemetry Part 1: Sinatra'
 date: 2020-08-07T18:27:00-04:00
 lastmod: 2020-08-07T18:27:00-04:00

--- a/content/posts/2020/2020-08-18-burnout-sucks/index.md
+++ b/content/posts/2020/2020-08-18-burnout-sucks/index.md
@@ -1,4 +1,5 @@
 ---
+author: gene
 title: 'Burnout Sucks'
 date: 2020-08-18T23:05:00-04:00
 lastmod: 2020-08-18T23:05:00-04:00

--- a/content/posts/2020/2020-09-06-otel-part-2-redos.md
+++ b/content/posts/2020/2020-09-06-otel-part-2-redos.md
@@ -1,4 +1,5 @@
 ---
+author: gene
 title: 'OpenTelemetry Part 2: Redoing Instrumentation'
 date: 2020-09-06T21:30:00-04:00
 lastmod: 2020-09-06T21:30:00-04:00

--- a/content/posts/2020/2020-09-22-otel-part-3-v060/index.md
+++ b/content/posts/2020/2020-09-22-otel-part-3-v060/index.md
@@ -1,4 +1,5 @@
 ---
+author: gene
 title: 'OpenTelemetry Part 3: v0.6.0 gems and VMPooler'
 date: 2020-10-05T18:20:00-04:00
 lastmod: 2020-10-05T18:20:00-04:00

--- a/content/posts/2020/2020-11-13-epomaker-gk68xs.markdown
+++ b/content/posts/2020/2020-11-13-epomaker-gk68xs.markdown
@@ -1,4 +1,5 @@
 ---
+author: gene
 title: 'Epomaker GK68XS: A great keyboard, horrific order fulfillment'
 date: 2020-11-13T20:10:00-05:00
 lastmod: 2020-11-13T20:10:00-05:00

--- a/content/posts/2022/2022-01-09-introducing-my-home-assistant-setup/index.md
+++ b/content/posts/2022/2022-01-09-introducing-my-home-assistant-setup/index.md
@@ -1,4 +1,5 @@
 ---
+author: gene
 title: Introducing My Home Assistant Setup
 date: 2022-01-09T23:00:00-05:00
 lastmod: 2022-01-09T23:00:00-05:00

--- a/content/posts/2022/2022-02-06-that-time-i-forgot-to-create-alerts-for-a-leak-sensor/index.md
+++ b/content/posts/2022/2022-02-06-that-time-i-forgot-to-create-alerts-for-a-leak-sensor/index.md
@@ -1,4 +1,5 @@
 ---
+author: gene
 title: That time I forgot to create alerts for a leak sensor
 date: 2022-02-20T16:00:00-05:00
 lastmod: 2022-02-20T16:00:00-05:00


### PR DESCRIPTION
## Summary

7 posts were missing an explicit `author:` field in their front matter. The author page template queries `Params.author` directly (`where .Site.RegularPages "Params.author" $authorShortName`), so posts without this field were silently excluded from the listing.

Affected posts (all `author: gene`):
- `2020-08-07-otel-part-1-sinatra`
- `2020-08-18-burnout-sucks`
- `2020-09-06-otel-part-2-redos`
- `2020-09-22-otel-part-3-v060`
- `2020-11-13-epomaker-gk68xs`
- `2022-01-09-introducing-my-home-assistant-setup`
- `2022-02-06-that-time-i-forgot-to-create-alerts-for-a-leak-sensor`

## Test plan

- [x] `grep -rL "^author:"` returns no results across all posts
- [x] `hugo --minify` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)