### PR TITLE
feat: add prev/next post navigation to single post pages

### DIFF
--- a/assets/css/_syntax-highlighting.scss
+++ b/assets/css/_syntax-highlighting.scss
@@ -55,6 +55,10 @@ $monospace-font-family: Menlo, Consolas, Monaco, "Courier New", Courier, monospa
 
 /* Multi-line code blocks */
 
+pre {
+  overflow-x: auto;
+}
+
 div.highlight,
 figure.highlight {
   position: relative;

--- a/assets/css/_theme.scss
+++ b/assets/css/_theme.scss
@@ -379,6 +379,10 @@ footer.page-footer {
         align-items: center;
         gap: 0.75em;
         max-width: 46%;
+
+        a.btn-floating {
+            flex-shrink: 0;
+        }
     }
 
     .post-nav-next {

--- a/assets/css/_theme.scss
+++ b/assets/css/_theme.scss
@@ -366,8 +366,50 @@ footer.page-footer {
 }
 /******************************************************************************/
 
-/** 12. Media Queries
+/** 12. Post Navigation
 *******************************************************************************/
+.post-navigation {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .post-nav-prev,
+    .post-nav-next {
+        display: flex;
+        align-items: center;
+        gap: 0.75em;
+        max-width: 46%;
+    }
+
+    .post-nav-next {
+        text-align: right;
+    }
+
+    .post-nav-title {
+        line-height: 1.3;
+    }
+}
+/******************************************************************************/
+
+/** 13. Media Queries
+*******************************************************************************/
+@media screen and (max-width: 600px) {
+    .post-navigation {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5em;
+
+        .post-nav-prev,
+        .post-nav-next {
+            max-width: 100%;
+        }
+
+        .post-nav-next {
+            justify-content: flex-end;
+        }
+    }
+}
+
 @media screen and (max-width: 600px) {
 	.blog-logo {
         display: none;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -55,6 +55,7 @@
                     </div>
                 </div>
         </article>
+        {{ partial "post-nav.html" . }}
     </div>
 </div>
 {{ partial "sidebar-author.html" . }}

--- a/layouts/partials/post-nav.html
+++ b/layouts/partials/post-nav.html
@@ -1,0 +1,20 @@
+{{ $prev := .PrevInSection }}
+{{ $next := .NextInSection }}
+{{ if or $prev $next }}
+<div class="post-navigation card-panel grey lighten-5" role="navigation">
+    <div class="post-nav-prev">
+        {{ with $prev }}
+        <a class="btn-floating btn-small waves-effect waves-light deep-orange valign" href="{{ .RelPermalink }}"
+            title="{{ .Title }}"><i class="fas fa-chevron-left"></i></a>
+        <a class="post-nav-title valign link-theme-active-to-black" href="{{ .RelPermalink }}">{{ .Title }}</a>
+        {{ end }}
+    </div>
+    <div class="post-nav-next">
+        {{ with $next }}
+        <a class="post-nav-title valign link-theme-active-to-black" href="{{ .RelPermalink }}">{{ .Title }}</a>
+        <a class="btn-floating btn-small waves-effect waves-light deep-orange valign" href="{{ .RelPermalink }}"
+            title="{{ .Title }}"><i class="fas fa-chevron-right"></i></a>
+        {{ end }}
+    </div>
+</div>
+{{ end }}


### PR DESCRIPTION
## Summary

- Adds a `post-nav.html` partial rendered below each post with ← newer and older → navigation
- Buttons use the same `btn-floating btn-small waves-effect waves-light deep-orange` style as the list paginator
- Post titles link with `link-theme-active-to-black` for proper contrast
- Wrapped in `card-panel grey lighten-5` to match the article card style
- On mobile (≤600px): stacks vertically with prev left-aligned and next right-aligned

## Test plan

- [x] Mid-list post shows both prev and next
- [x] Newest post shows only next (older)
- [x] Oldest post shows only prev (newer)
- [x] Mobile layout stacks cleanly
- [x] `hugo --minify` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)