### PR TITLE
Reduce mobile side padding for wider reading area

### DIFF
--- a/assets/css/_theme.scss
+++ b/assets/css/_theme.scss
@@ -432,6 +432,14 @@ footer.page-footer {
     .sidebar .card-panel {
         padding: 12px;
     }
+
+    .post-header-image {
+        margin: -12px -12px 0 -12px;
+    }
+
+    .post-list-image {
+        margin: 0 -12px 12px -12px;
+    }
 }
 
 /* The full size text is 2.1rem but that doesn't work well on mobile... */

--- a/assets/css/_theme.scss
+++ b/assets/css/_theme.scss
@@ -422,6 +422,16 @@ footer.page-footer {
   .blog-title span {
 			 display: inline;
 	}
+
+    .content-wrapper,
+    .sidebar {
+        margin: 4px 2px 4px 2px;
+    }
+
+    .content-wrapper .card-panel,
+    .sidebar .card-panel {
+        padding: 12px;
+    }
 }
 
 /* The full size text is 2.1rem but that doesn't work well on mobile... */


### PR DESCRIPTION
## Summary

- On screens ≤600px, reduce `.content-wrapper` and `.sidebar` margins from 10px/side to 2px/side
- Reduce Materialize `card-panel` padding from 20px to 12px on mobile
- Total horizontal chrome drops from ~60px to ~28px, giving noticeably more content width

## Test plan

- [x] Check single post on mobile — content area should be wider with a thin border on each side
- [x] Check index/list pages on mobile — same improvement
- [x] Verify desktop layout is unchanged (rules are inside `@media (max-width: 600px)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)