### PR TITLE
Fix footer disclaimer wording

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,7 @@
 <!-- DISCLAIMER -->
 <div class="row">
     <div class="col l12 m12 s12 center-align">
-        <strong>Disclaimer:</strong> All code, opinion and information on this
-        blog are my personal view and do not represent or relate my past and / or current employer's
-        view and / or business insides in any way.
+        <strong>Disclaimer:</strong> All code, opinions, and information on this site are my personal views and do not represent my past or current employer's views or business interests.
     </div>
 </div>
 <footer class="page-footer transparent">


### PR DESCRIPTION
## Summary

- Rewrites the footer disclaimer which had grammatical issues ("business insides", singular "view", "blog" instead of "site")
- New text: *All code, opinions, and information on this site are my personal views and do not represent my past or current employer's views or business interests.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)